### PR TITLE
Add go to first/last page buttons on mobile to leaderboard and player scores endpoints

### DIFF
--- a/src/lib/components/common/arrow-pagination.svelte
+++ b/src/lib/components/common/arrow-pagination.svelte
@@ -5,51 +5,37 @@
 </script>
 
 <script lang="ts">
+   import ArrowButton from '$lib/components/common/pagination/arrow-button.svelte';
+
    export let page: number;
    export let maxPages: number;
    export let pageClicked: PageCallback;
+   export let withFirstLast: boolean = false;
 </script>
 
 <nav class="pagination">
-   {#if page > 1}
-      <button on:click={() => pageClicked(page - 1)} class="button arrow">
-         <span class="icon is-small">
-            <i class="fas fa-arrow-left" />
-         </span>
-      </button>
-   {:else}
-      <button class="button arrow" disabled>
-         <span class="icon is-small">
-            <i class="fas fa-arrow-left" />
-         </span>
-      </button>
-   {/if}
-   {#if page < maxPages}
-      <button on:click={() => pageClicked(page + 1)} class="button arrow">
-         <span class="icon is-small">
-            <i class="fas fa-arrow-right" />
-         </span>
-      </button>
-   {:else}
-      <button class="button arrow" disabled>
-         <span class="icon is-small">
-            <i class="fas fa-arrow-right" />
-         </span>
-      </button>
-   {/if}
+  <section class="btn-group">
+    {#if withFirstLast}
+      <ArrowButton icon="fa-step-backward" on:click={() => pageClicked(1)} disabled={page <= 1}/>
+    {/if}
+    <ArrowButton icon="fa-arrow-left" on:click={() => pageClicked(page - 1)} disabled={page <= 1}/>
+  </section>
+
+  <section class="btn-group">
+    <ArrowButton icon="fa-arrow-right" on:click={() => pageClicked(page + 1)} disabled={page >= maxPages}/>
+
+    {#if withFirstLast}
+      <ArrowButton icon="fa-step-forward" on:click={() => pageClicked(maxPages)} disabled={page >= maxPages}/>
+    {/if}
+  </section>
 </nav>
 
 <style>
-   .pagination .button {
-      background-color: #2d2d2d !important;
-      border-color: var(--foreground) !important;
-      color: var(--alternate) !important;
-      display: flex;
-   }
-   .pagination .button:hover {
-      color: var(--scoreSaberYellow) !important;
-   }
    .pagination {
       margin-bottom: 0.1rem;
+   }
+
+   .btn-group {
+       display: inline-flex;
    }
 </style>

--- a/src/lib/components/common/pagination/arrow-button.svelte
+++ b/src/lib/components/common/pagination/arrow-button.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+   export let icon: string;
+   export let size: string = 'is-small';
+   export let disabled: boolean = false;
+
+   $: iconSize = `icon ${size ?? ''}`
+   $: fasIcon = `fas ${icon ?? ''}`
+</script>
+
+<button class="button" on:click {disabled}>
+   <span class={iconSize}>
+      <i class={fasIcon} />
+   </span>
+</button>
+
+<style>
+   button {
+      background-color: #2d2d2d !important;
+      border-color: var(--foreground) !important;
+      color: var(--alternate) !important;
+      display: flex;
+   }
+
+   button:hover {
+      color: var(--scoreSaberYellow) !important;
+   }
+</style>

--- a/src/lib/components/player/score.svelte
+++ b/src/lib/components/player/score.svelte
@@ -140,7 +140,7 @@
                <ClassicPagination totalItems={score.leaderboard.plays} pageSize={scoresPerPage} currentPage={leaderboardPage} {changePage} />
             </div>
             <div class="mobile">
-               <ArrowPagination pageClicked={changePage} page={leaderboardPage} maxPages={Math.ceil(score.leaderboard.plays / scoresPerPage)} />
+               <ArrowPagination pageClicked={changePage} page={leaderboardPage} maxPages={Math.ceil(score.leaderboard.plays / scoresPerPage)} withFirstLast={true} />
             </div>
          {/if}
          {#if $scoreDataError}

--- a/src/routes/leaderboard/[leaderboardId].svelte
+++ b/src/routes/leaderboard/[leaderboardId].svelte
@@ -191,7 +191,7 @@
                         <ClassicPagination totalItems={$leaderboard.plays} pageSize={12} currentPage={$pageQuery.page} {changePage} />
                      </div>
                      <div class="mobile">
-                        <ArrowPagination pageClicked={changePage} page={$pageQuery.page} maxPages={Math.ceil($leaderboard.plays / 12)} />
+                        <ArrowPagination pageClicked={changePage} page={$pageQuery.page} maxPages={Math.ceil($leaderboard.plays / 12)} withFirstLast={true} />
                      </div>
                      {#if $leaderboardScoresError}
                         <Error error={$leaderboardScoresError} />

--- a/src/routes/u/[playerId].svelte
+++ b/src/routes/u/[playerId].svelte
@@ -261,6 +261,7 @@
                   pageClicked={changePage}
                   page={parseInt($pageQuery.page)}
                   maxPages={Math.ceil($playerData.scoreStats.totalPlayCount / scoresPerPage)}
+                  withFirstLast={true}
                />
             </div>
             <div class="ranking songs">
@@ -278,11 +279,12 @@
                   changePage={(e) => changePage(e)}
                />
             </div>
-            <div class="mobile">
+            <div class="mobile bottom-arrowpagination">
                <ArrowPagination
                   pageClicked={changePage}
                   page={parseInt($pageQuery.page)}
                   maxPages={Math.ceil($playerData.scoreStats.totalPlayCount / scoresPerPage)}
+                  withFirstLast={true}
                />
             </div>
          </div>
@@ -300,7 +302,7 @@
 <Modal show={$modal} />
 
 <style lang="scss">
-   .top-arrowpagination {
+   .top-arrowpagination, .bottom-arrowpagination {
       margin-top: 15px;
    }
    .gridTable {


### PR DESCRIPTION
Navigation on mobile is severely hampered with no way to get to the first page. Especially when expanding the leaderboard of a song on a player profile, the ability to quickly go to the first page and see the best scores is much needed IMO. On a desktop this is not a problem because there is full navigation through the subpages.

This PR adds go to first/last page buttons to the ArrowPagination component. I chose the icons that I think are appropriate, but of course I may be wrong. The display of new buttons is configurable using the "withFirstLast" property of updated ArrowPagination component. In this PR this option is enabled for leaderboard and player scores pages.

![image](https://user-images.githubusercontent.com/1758707/142940392-ea3c02ba-70a2-4e32-b957-111d593c7f46.png)
