### PR TITLE
fix: desktop leaderboard pagination

### DIFF
--- a/src/lib/components/common/pagination/pagination-nav.svelte
+++ b/src/lib/components/common/pagination/pagination-nav.svelte
@@ -4,7 +4,7 @@
     */
 
    import { createEventDispatcher } from 'svelte';
-   import generateNavigationOptions from './generateNavigationOptions';
+   import generateNavigationOptions, {PaginationOptions} from './generateNavigationOptions';
 
    const PREVIOUS_PAGE = 'PREVIOUS_PAGE';
    const NEXT_PAGE = 'NEXT_PAGE';
@@ -28,8 +28,13 @@
 
    $: totalPages = Math.ceil(totalItems / pageSize);
 
+   function isOptionDisabled(option: PaginationOptions) : boolean {
+      return (option.type === 'symbol' && option.symbol === NEXT_PAGE && currentPage >= totalPages) ||
+        (option.type === 'symbol' && option.symbol === PREVIOUS_PAGE && currentPage <= 1);
+   }
+
    function handleOptionClick(option) {
-      if (option.type === 'symbol' && option.symbol === ELLIPSIS) {
+      if (isOptionDisabled(option) || option.value === currentPage || (option.type === 'symbol' && option.symbol === ELLIPSIS)) {
          return;
       }
       dispatch('setPage', { page: option.value });
@@ -43,8 +48,7 @@
          class:number={option.type === 'number'}
          class:prev={option.type === 'symbol' && option.symbol === PREVIOUS_PAGE}
          class:next={option.type === 'symbol' && option.symbol === NEXT_PAGE}
-         class:disabled={(option.type === 'symbol' && option.symbol === NEXT_PAGE && currentPage >= totalPages) ||
-            (option.type === 'symbol' && option.symbol === PREVIOUS_PAGE && currentPage <= 1)}
+         class:disabled={isOptionDisabled(option)}
          class:ellipsis={option.type === 'symbol' && option.symbol === ELLIPSIS}
          class:active={option.type === 'number' && option.value == currentPage}
          on:click={() => handleOptionClick(option)}

--- a/src/lib/query-store.ts
+++ b/src/lib/query-store.ts
@@ -10,6 +10,10 @@ export function pageQueryStore<T extends object>(props: T) {
    let initialLoad = true;
    page.subscribe((p) => {
       let query = queryString.parse(p.query.toString(), { parseNumbers: true });
+
+      // set the default page to 1 after navigation if the query params do not contain the page parameter and the original props contained this field
+      if ('page' in props && !query?.page) query.page = 1;
+
       let newParams: T = props;
       for (let key in query) {
          if (key in props) newParams[key] = query[key];


### PR DESCRIPTION
- disabled desktop pagination options now do not dispatch setPage event
- set the default page to 1 after navigation if the query params do not contain the page parameter and the original props contained this field

![image](https://user-images.githubusercontent.com/1758707/143098480-f87bbd73-cd1b-4276-8aab-c5ed6bc45acc.png)
