### PR TITLE
fix: remove redirection of Oculus players to Steam

### DIFF
--- a/src/lib/components/player/player-link.svelte
+++ b/src/lib/components/player/player-link.svelte
@@ -118,6 +118,9 @@
       overflow: hidden;
       text-overflow: ellipsis;
    }
+   a span:hover {
+      color: var(--scoreSaberYellow)!important;
+   }
    span.default {
       color: var(--alternate);
    }

--- a/src/lib/components/player/player-link.svelte
+++ b/src/lib/components/player/player-link.svelte
@@ -4,13 +4,15 @@
    import type { LeaderboardPlayer, Player } from '$lib/models/PlayerData';
 
    export let player: Player | LeaderboardPlayer;
-   export let destination: string;
+   export let destination: string | null;
    export let external: boolean = false;
    export let countryImage: boolean = true;
 
-   $: playerClass = getPlayerClass(player);
+   let playerClass : string;
+   let playerTitle : string;
+   $: ([playerClass, playerTitle] = getPlayerClassAndTitle(player));
 
-   export function getPlayerClass(player: Player | LeaderboardPlayer): [string, string] {
+   export function getPlayerClassAndTitle(player: Player | LeaderboardPlayer): [string, string] {
       if (Permissions.checkPermissionNumber(player.permissions, Permissions.security.PANDA)) {
          return ['panda', 'Owner of ScoreSaber'];
       }
@@ -56,20 +58,27 @@
    }
 </script>
 
-{#if external}
-   <a title={playerClass[1]} rel="external" target="_blank" href={destination} class="player-link">
-      {#if countryImage}
-         <CountryImage country={player.country} />
-      {/if}
-      <span class={playerClass[0]}>{player.name}</span>
-   </a>
+{#if destination !== null}
+   {#if external}
+      <a title={playerTitle} rel="external" target="_blank" href={destination} class="player-link">
+         {#if countryImage}
+            <CountryImage country={player.country}/>
+         {/if}
+         <span class={playerClass}>{player.name}</span>
+      </a>
+   {:else}
+      <a title={playerTitle} href={destination}>
+         {#if countryImage}
+            <CountryImage country={player.country}/>
+         {/if}
+         <span class={playerClass}>{player.name}</span>
+      </a>
+   {/if}
 {:else}
-   <a title={playerClass[1]} href={destination}>
-      {#if countryImage}
-         <CountryImage country={player.country} />
-      {/if}
-      <span class={playerClass[0]}>{player.name}</span>
-   </a>
+   {#if countryImage}
+      <CountryImage country={player.country}/>
+   {/if}
+   <span class={playerClass}>{player.name}</span>
 {/if}
 
 <style lang="scss">
@@ -108,6 +117,9 @@
    span {
       overflow: hidden;
       text-overflow: ellipsis;
+   }
+   span.default {
+      color: var(--alternate);
    }
    span.panda {
       color: var(--panda);

--- a/src/routes/u/[playerId].svelte
+++ b/src/routes/u/[playerId].svelte
@@ -139,6 +139,15 @@
       await fetcher(`/api/user/${player.id}/giveRole/${role}`, { withCredentials: true });
       refreshPlayerData({ forceRevalidate: true, softRefresh: true });
    }
+
+   let isOculusPlayer : boolean;
+   $: isOculusPlayer = !!$playerData?.profilePicture?.endsWith('oculus.png');
+
+   let playerId : string | null;
+   $: playerId = $playerData?.id ?? null;
+
+   let destination : string | null;
+   $: destination = playerId && !isOculusPlayer ? `https://steamcommunity.com/profiles/${playerId}` : null
 </script>
 
 <head>
@@ -171,7 +180,7 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
             <div class="column is-narrow">
                <div class="profile-picture">
                   <div class="image is-128x128 rounded" style="background-image: url({$playerData.profilePicture}); background-size: cover;">
-                     {#if parseInt($playerData.id) >= 70000000000000000}
+                     {#if parseInt(playerId) >= 70000000000000000}
                         <button on:click={() => handleRefresh($playerData)} class="button refresh is-small is-dark mt-2" title="Refresh User">
                            <span class="icon is-small">
                               <i class="fas fa-sync-alt" />
@@ -195,7 +204,7 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
                      player={$playerData}
                      external={true}
                      countryImage={true}
-                     destination={`https://steamcommunity.com/profiles/${$playerData.id}`}
+                     {destination}
                   />
                   {#if !$playerData.banned}
                      <div class="divider" />
@@ -241,8 +250,8 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
       {/if}
    </div>
 
-   {#if $playerData?.id && !$playerData.banned}
-      {#key $playerData.id}
+   {#if playerId && !$playerData.banned}
+      {#key playerId}
          <div class="window has-shadow noheading">
             <Badges player={$playerData} />
             {#if !$playerData.inactive}
@@ -269,7 +278,7 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
             <div class="ranking songs">
                <div class="ranking songs gridTable">
                   {#each $scoreData as score, i (score.score.id)}
-                     <Score openModal={openScoreModal} {pageDirection} {score} row={i + 1} playerId={$playerData.id} />
+                     <Score openModal={openScoreModal} {pageDirection} {score} row={i + 1} playerId={playerId} />
                   {/each}
                </div>
             </div>

--- a/src/routes/u/[playerId].svelte
+++ b/src/routes/u/[playerId].svelte
@@ -140,14 +140,8 @@
       refreshPlayerData({ forceRevalidate: true, softRefresh: true });
    }
 
-   let isOculusPlayer : boolean;
-   $: isOculusPlayer = !!$playerData?.profilePicture?.endsWith('oculus.png');
-
-   let playerId : string | null;
-   $: playerId = $playerData?.id ?? null;
-
-   let destination : string | null;
-   $: destination = playerId && !isOculusPlayer ? `https://steamcommunity.com/profiles/${playerId}` : null
+   let isSteamPlayer : boolean;
+   $: isSteamPlayer = $playerData?.id && parseInt($playerData.id, 10) >= 70000000000000000;
 </script>
 
 <head>
@@ -168,19 +162,19 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
 
 <div class="section">
    <div class="content">
-      {#if !$playerDataError && !$playerData}
-         <Loader />
-      {/if}
       {#if $playerDataError}
          <Error error={$playerDataError} />
+      {:else if !$playerData}
+         <Loader />
       {/if}
+
       {#if $playerData}
          <div in:fly={{ x: 20, duration: 1000 }} class="columns">
             <!-- Profile picture & badges -->
             <div class="column is-narrow">
                <div class="profile-picture">
                   <div class="image is-128x128 rounded" style="background-image: url({$playerData.profilePicture}); background-size: cover;">
-                     {#if parseInt(playerId) >= 70000000000000000}
+                     {#if isSteamPlayer}
                         <button on:click={() => handleRefresh($playerData)} class="button refresh is-small is-dark mt-2" title="Refresh User">
                            <span class="icon is-small">
                               <i class="fas fa-sync-alt" />
@@ -204,7 +198,7 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
                      player={$playerData}
                      external={true}
                      countryImage={true}
-                     {destination}
+                     destination={isSteamPlayer ? `https://steamcommunity.com/profiles/${$playerData.id}` : null}
                   />
                   {#if !$playerData.banned}
                      <div class="divider" />
@@ -250,8 +244,8 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
       {/if}
    </div>
 
-   {#if playerId && !$playerData.banned}
-      {#key playerId}
+   {#if $playerData?.id && !$playerData.banned}
+      {#key $playerData.id}
          <div class="window has-shadow noheading">
             <Badges player={$playerData} />
             {#if !$playerData.inactive}
@@ -278,7 +272,7 @@ Replays Watched by Others: ${metadata.scoreStats.replaysWatched.toLocaleString('
             <div class="ranking songs">
                <div class="ranking songs gridTable">
                   {#each $scoreData as score, i (score.score.id)}
-                     <Score openModal={openScoreModal} {pageDirection} {score} row={i + 1} playerId={playerId} />
+                     <Score openModal={openScoreModal} {pageDirection} {score} row={i + 1} playerId={$playerData?.id} />
                   {/each}
                </div>
             </div>


### PR DESCRIPTION
Currently the API is missing the externalProfileUrl field or something like that so it checks if profilePicture ends with 'oculus.png'. However, this breaks down when you change the default Oculus image.