### PR TITLE
fix: cancelling request by enter on rankings

### DIFF
--- a/src/lib/components/common/text-input.svelte
+++ b/src/lib/components/common/text-input.svelte
@@ -15,21 +15,27 @@
 
    let timeout = null;
 
+   function forwardInput() {
+      $requestCancel.cancel('Input Changed');
+      updateCancelToken();
+      if (value === '') value = null;
+      onInput(value);
+   }
+
    function onChange() {
       if (timeout) {
          clearTimeout(timeout);
       }
-      timeout = setTimeout(() => {
-         $requestCancel.cancel('Input Changed');
-         updateCancelToken();
-         if (value === '') value = null;
-         onInput(value);
-      }, 1000);
+      timeout = setTimeout(forwardInput, 1000);
    }
 
    function onKeyDown(e: KeyboardEvent) {
+      if (timeout) {
+         clearTimeout(timeout);
+         timeout = null;
+      }
       if (e.key === 'Enter') {
-         onInput(value);
+         forwardInput();
       }
    }
 


### PR DESCRIPTION
Currently we can't see the result when input `nickname<enter>` on rankings page advanced search.
This is a fix about that.