### PR TITLE
Fix scores page overflow on mobile

### DIFF
--- a/src/lib/components/leaderboard/small-song-info.svelte
+++ b/src/lib/components/leaderboard/small-song-info.svelte
@@ -122,7 +122,7 @@
 
    @media screen and (max-width: 769px), print {
       .song-info {
-         width: 280px;
+         width: auto;
       }
    }
 


### PR DESCRIPTION
Forcing the song info width doesn't seem to do much but causes the page size to be wonky on most mobile devices (see for example [this message](https://discord.com/channels/501624026532151296/904574187782438932/956493860392022046) on the discord).
We could add it back as a max-width but after testing at different screen sizes (e.g. 760px wide), I think not limiting it makes more sense.