### PR TITLE
Search promises fix with potential errors

### DIFF
--- a/src/lib/components/common/search.svelte
+++ b/src/lib/components/common/search.svelte
@@ -92,7 +92,7 @@
       searchValue = value.trim();
       cancel.cancel('new search');
       cancel = axios.CancelToken.source();
-      Promise.all([
+      Promise.allSettled([
          fetcher<PlayerCollection>(
             queryString.stringifyUrl({
                url: '/api/players',
@@ -112,7 +112,15 @@
             { cancelToken: cancel.token, withCredentials: true }
          )
       ])
-         .then(([{ players }, { leaderboards }]) => {
+         .then((result) => {
+            let players = [];
+            let leaderboards = [];
+            if (result[0].status === 'fulfilled' && result[0].value?.players) {
+               players = result[0].value.players;
+            }
+            if (result[1].status === 'fulfilled' && result[1].value?.leaderboards) {
+               leaderboards = result[1].value.leaderboards;
+            }
             searchResults = { players, leaderboards };
          })
          .catch(() => {


### PR DESCRIPTION
If no players are found within the search, the api returns a 404 Error and the Promise.all() bails out and would therefore not load the leaderboards anymore.
Promise.allSettled() should instead do the trick here: https://stackoverflow.com/questions/30362733/handling-errors-in-promise-all.