### PR TITLE
Re-scale rank chart for returning players

### DIFF
--- a/src/lib/components/player/rank-chart.svelte
+++ b/src/lib/components/player/rank-chart.svelte
@@ -11,6 +11,15 @@
    });
 
    history.push(player.rank);
+   
+   // If this player stopped playing for a while, but has picked up again, then remove the 
+   // #999999 ranks at the beginning to make the chart more useful
+   if (history.some(h => h !== 999999)) {
+      while (history[0] === 999999) {
+         history.shift();
+      }
+   }
+
    onMount(() => {
       window.addEventListener('resize', () => {
          options = getOptions();


### PR DESCRIPTION
I've just got back into using ScoreSaber after the Quest update (yay!), after previously using the older version back on 1.13.

On the web front-end, if you've been inactive for a while and are given a #999999 global rank, then the rank chart is pretty unhelpful until 50 days have passed:

![image](https://user-images.githubusercontent.com/3321773/166724165-78ddb3cd-ea74-47cc-9131-98c3aed66f81.png)

This PR removes #999999 ranks from the beginning of the history, if there are real ranks following it:

![image](https://user-images.githubusercontent.com/3321773/166724085-cc1e8627-ff56-435f-a132-546621358ff9.png)

(If the entire history is #999999 ranks, then it isn't changed.)

I personally think this is an improvement since it makes the chart more useful to a returning player, but I understand it's a subjective change, so up to you on whether you'd like to merge!