### PR TITLE
Don't apply multipliers twice

### DIFF
--- a/src/lib/components/player/score-modal.svelte
+++ b/src/lib/components/player/score-modal.svelte
@@ -17,7 +17,7 @@
       let scoreCalc = score.score.baseScore;
       let maxScore = score.leaderboard.maxScore;
 
-      return ((scoreCalc / maxScore) * 100) / score.score.multiplier;
+      return ((scoreCalc / maxScore) * 100);
    }
 </script>
 


### PR DESCRIPTION
BaseScore and MaxScore are already normalized and don't need to be divided by the multipliers again.