### PR TITLE
rankings: fix ambiguous country filters

### DIFF
--- a/src/shared/country-region/index.ts
+++ b/src/shared/country-region/index.ts
@@ -38,7 +38,10 @@ function parseCountryRegionParam(value: unknown): CountryRegionFilterValue | und
 
    const csv = raw.join(',');
    const parsedRegionCode = regionCodeSchema.safeParse(raw[0]);
-   const region = regionByCountries.get(csv) ?? (raw.length === 1 && parsedRegionCode.success ? regionByCode.get(parsedRegionCode.data) : undefined);
+   const parsedCountryCode = countryCodeSchema.safeParse(raw[0]);
+   const region =
+      regionByCountries.get(csv) ??
+      (raw.length === 1 && parsedRegionCode.success && !parsedCountryCode.success ? regionByCode.get(parsedRegionCode.data) : undefined);
    if (region) return { kind: 'region', region: region.code };
 
    const countries = raw.flatMap((code) => {


### PR DESCRIPTION
### Closes: #129 
Fixes country filter parsing for ISO country codes that overlap internal region codes.

Previously:
 `countries=SA` parsed as South America instead of Saudi Arabia
 `countries=AF` parsed as Africa instead of Afghanistan
 `countries=AS` parsed as Asia instead of America Samoa
 `countries=NA` parsed as North America instead of Namibia

Now single country codes are parsed as countries. Regions still parse correctly from their expanded CSV, which is what `formatCountryRegionParam()` already uses

#### Testing
 `bun run lint`
 `bun run build`