### PR TITLE
scores: show hit score percent on hover (#113)

### DIFF
--- a/src/modules/scores/hand-accuracy-ring.tsx
+++ b/src/modules/scores/hand-accuracy-ring.tsx
@@ -3,6 +3,8 @@
 import { Timer } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 
+import { HitScoreValue } from './hit-score-value';
+
 import { Stat } from '@/shared/components/stat';
 import { cn } from '@/shared/format/helpers';
 
@@ -53,7 +55,7 @@ export function HandAccuracyRing({ side, accuracy, averageCut, timeDependence }:
                      className={cn(ringColor, 'transition-[stroke-dashoffset] duration-700 ease-out')}
                   />
                </svg>
-               <span className="absolute text-sm font-semibold tabular-nums">{accuracy.toFixed(2)}</span>
+               <HitScoreValue value={accuracy} className="absolute min-h-10 min-w-16 rounded-sm text-sm font-semibold" />
             </div>
             <Stat icon={Timer} label={t('score.timeDependenceShort')} className={cn('gap-1.5 px-2 py-0.5 text-[11px]', bgColor, borderColor)}>
                {timeDependence.toFixed(3)}

--- a/src/modules/scores/hit-score-value.tsx
+++ b/src/modules/scores/hit-score-value.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { cn } from '@/shared/format/helpers';
+
+const MAX_HIT_SCORE = 115;
+
+interface HitScoreValueProps {
+   value: number;
+   decimals?: number;
+   className?: string;
+}
+
+function formatHitScorePercent(value: number) {
+   return `${((value / MAX_HIT_SCORE) * 100).toFixed(2)}%`;
+}
+
+export function HitScoreValue({ value, decimals = 2, className }: HitScoreValueProps) {
+   const points = Number.isFinite(value) ? value.toFixed(decimals) : '--';
+   const percent = Number.isFinite(value) ? formatHitScorePercent(value) : '--';
+
+   return (
+      <span
+         tabIndex={0}
+         aria-label={`${points} (${percent})`}
+         className={cn(
+            'group inline-grid cursor-help place-items-center tabular-nums outline-none focus-visible:ring-1 focus-visible:ring-current/40',
+            className
+         )}
+      >
+         <span
+            aria-hidden="true"
+            className="col-start-1 row-start-1 transition-opacity duration-150 group-hover:opacity-0 group-focus-visible:opacity-0"
+         >
+            {points}
+         </span>
+         <span
+            aria-hidden="true"
+            className="col-start-1 row-start-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
+         >
+            {percent}
+         </span>
+      </span>
+   );
+}

--- a/src/modules/scores/score-stats-detail.tsx
+++ b/src/modules/scores/score-stats-detail.tsx
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { ScoreAccuracyChart } from './chart/score-accuracy-chart';
 import { ScoreAccuracyDistributionChart, ScoreAccuracyTimelineChart } from './chart/score-replay-analysis-charts';
 import { HandAccuracyRing } from './hand-accuracy-ring';
+import { HitScoreValue } from './hit-score-value';
 
 import { Button } from '@/components/ui/button';
 
@@ -259,7 +260,7 @@ function GridAccuracy({ grid }: { grid: ScoreControllerGetScoreStatsResponse['gr
                            color: `rgb(${r}, ${g}, ${b})`
                         }}
                      >
-                        {cell.avgScore.toFixed(1)}
+                        <HitScoreValue value={cell.avgScore} decimals={1} className="size-full rounded-sm" />
                      </div>
                   );
                })


### PR DESCRIPTION
i like this feature
#### Description
adds hover/focus behavior to hit score values in the score detail panel so players can view the equivalent % value

applies to:
- left and right hand average hit score values
- each populated grid accuracy cell

the percentage is shown with two decimals and the hover targets are slightly larger than the visible text so the interaction is easier to use and cursor doesn't block text

[ScoreSaber Hub post](https://hub.scoresaber.com/b/feature-requests/posts/post_01kst9bw7nfex8nb69nt6zx12m)

Closes #113

#### Testing

https://github.com/user-attachments/assets/6507e15d-92a5-41d1-8f62-403d57ee9617

 `bun run lint`
 `bun run build`