### PR TITLE
shell: fix glitchy sidebar toggle animation (#132)

### DIFF
--- a/src/shell/main-content.tsx
+++ b/src/shell/main-content.tsx
@@ -13,7 +13,7 @@ function MainContentInner({ children, debugPageBackground }: { children: React.R
       <main
          id="main-content"
          className={cn(
-            'relative flex min-h-dvh flex-col pt-(--content-offset-top) pb-(--content-offset-bottom) transition-[padding-left] duration-200 ease-in-out lg:pt-0 lg:pb-0',
+            'relative flex min-h-dvh flex-col pt-(--content-offset-top) pb-(--content-offset-bottom) transition-[padding-left] duration-300 ease-in-out lg:pt-0 lg:pb-0',
             collapsed ? 'lg:pl-14' : 'lg:pl-61 3xl:pl-68'
          )}
       >

--- a/src/shell/sidebar.tsx
+++ b/src/shell/sidebar.tsx
@@ -213,11 +213,32 @@ export function Sidebar() {
    return (
       <aside
          className={cn(
-            'bg-background fixed top-0 left-0 z-40 hidden h-screen flex-col border-r transition-[width] duration-200 ease-in-out lg:flex',
+            'bg-background fixed top-0 left-0 z-40 hidden h-screen flex-col border-r transition-[width] duration-300 ease-in-out lg:flex overflow-x-hidden',
             collapsed ? 'w-14' : 'w-61 3xl:w-68'
          )}
       >
-         {collapsed ? <CollapsedSidebar onExpand={toggle} /> : <ExpandedSidebar onCollapse={toggle} />}
+         <div className="relative h-full w-full">
+            <div
+               aria-hidden={!collapsed}
+               inert={!collapsed}
+               className={cn(
+                  'absolute inset-0 w-14 flex flex-col transition-opacity duration-300 ease-in-out',
+                  collapsed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+               )}
+            >
+               <CollapsedSidebar onExpand={toggle} />
+            </div>
+            <div
+               aria-hidden={collapsed}
+               inert={collapsed}
+               className={cn(
+                  'absolute inset-0 w-61 3xl:w-68 flex flex-col transition-opacity duration-300 ease-in-out',
+                  collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'
+               )}
+            >
+               <ExpandedSidebar onCollapse={toggle} />
+            </div>
+         </div>
       </aside>
    );
 }


### PR DESCRIPTION
Fixes #132

**changes:**
- refactored the sidebar to use fixed positioning with opacity based crossfades rather than constant unmount/remounting
- added the react 19's `inert` attribute to hide the inactive sidebar state from pointer events
- slightly increased `main-content.tsx` transition timing to `duration-300` to better sync with the new sidebar animation

this eliminates the layout thrashing and text jitter from the container being resized

also by keeping both states in the DOM and animating `opacity` the browser doesn't need to trigger heavy reflows on every frame

## before

https://github.com/user-attachments/assets/f854afec-1ad7-4930-b57d-65cefd303049

## after

https://github.com/user-attachments/assets/3fbcbd25-bd21-4ef3-8675-c5ced3baadab