### PR TITLE
player: fix flag hover popup (#115)

### DIFF
--- a/src/modules/player/shared/player-link.tsx
+++ b/src/modules/player/shared/player-link.tsx
@@ -46,20 +46,20 @@ export function PlayerLink({ player, outLink, className, withPFP, variant = 'lin
          />
       </a>
    ) : (
-      <PlayerHoverCard playerId={player.id}>
-         <playerRoute.Link
-            className="group/link text-foreground flex items-center overflow-hidden font-semibold"
-            params={{ playerId: player.id }}
-            search={{ page: 1, sort: 'top' }}
-         >
-            <CountryImage country={player.country} className="shrink-0" />
+      <playerRoute.Link
+         className="group/link text-foreground flex items-center overflow-hidden font-semibold"
+         params={{ playerId: player.id }}
+         search={{ page: 1, sort: 'top' }}
+      >
+         <CountryImage country={player.country} className="shrink-0" />
+         <PlayerHoverCard playerId={player.id}>
             <PlayerName
                player={player}
                className={cn('ml-2 truncate', isInactive && 'opacity-50', className)}
                playerStyle={playerSummary.roleClassName}
             />
-         </playerRoute.Link>
-      </PlayerHoverCard>
+         </PlayerHoverCard>
+      </playerRoute.Link>
    );
 
    return (


### PR DESCRIPTION
Fixes #115 

#### changes
- limited the player detail hover popup to the player name instead of the full player link to prevent overlap

#### testing


https://github.com/user-attachments/assets/056f9516-ad21-4bc0-acac-ead7dacce50a