### PR TITLE
profile: show pp for inactive players (#135)

### DIFF
--- a/src/modules/player/profile/player-profile-header.tsx
+++ b/src/modules/player/profile/player-profile-header.tsx
@@ -112,7 +112,7 @@ export function PlayerProfileHeader({ player, aliases, actions, children }: Play
                         {aliases && <PlayerAliases aliases={aliases} playerId={player.id} />}
                      </div>
 
-                     {isActive && (
+                     {!playerSummary.isBanned && (
                         <StatusBadge tooltip={t('common.performancePoints')} className={ppBadgeClass}>
                            {formatPP(stats.totalPP)}
                            <span className={ppUnitClass}>pp</span>


### PR DESCRIPTION
Fixes #135 

#### changes
- changed the profile header to show the pp badge for inactive players
- keeps the inactive badge visible separately