### PR TITLE
profile: fix searched scores empty state (#146)

### DIFF
--- a/src/routes/u/$playerId/route.tsx
+++ b/src/routes/u/$playerId/route.tsx
@@ -191,6 +191,7 @@ function PlayerProfileRouteContent({
                      page={input.search.page}
                      sort={input.search.sort}
                      search={input.search.search}
+                     hasScores={player.stats.totalSubmittedPlays > 0}
                      hasContentAbove={!player.inactive || hasBioContent}
                      parseSearch={parseSearch}
                   />
@@ -227,6 +228,7 @@ function PlayerScoresSection({
    page,
    sort,
    search,
+   hasScores,
    hasContentAbove,
    parseSearch
 }: {
@@ -235,6 +237,7 @@ function PlayerScoresSection({
    page: number;
    sort: PlayerControllerGetPlayerScoresSort;
    search?: string;
+   hasScores: boolean;
    hasContentAbove: boolean;
    parseSearch: ParsePlayerSearch;
 }) {
@@ -243,7 +246,7 @@ function PlayerScoresSection({
    const buildHref = (nextSearch?: Partial<PlayerProfileSearch>) => buildPlayerHref(playerId, nextSearch);
    const getPageHref = (nextPage: number) => buildHref(updateSearchParams(currentSearch, { page: nextPage > 1 ? nextPage : undefined }));
 
-   const hasNoScoresAtAll = scores.metadata.totalItems === 0;
+   const hasNoScoresAtAll = !hasScores;
 
    return (
       <div className="pb-3">


### PR DESCRIPTION
Fixes #146

#### changes
- fixes the empty state check that only used `scores.metadata.totalItems === 0`
- adds an explicit `hasActiveSearch` check so searched score results with `totalItems === 0` are not treated as a player having no scores
- requires `page === 1` before showing the "No scores yet" state, so out-of-range pages use the normal empty results state