### PR TITLE
time: dynamically fit relative timestamps (#158)

### DIFF
--- a/src/modules/scores/leaderboard/leaderboard-scores-table.tsx
+++ b/src/modules/scores/leaderboard/leaderboard-scores-table.tsx
@@ -146,7 +146,13 @@ function LeaderboardScoreCard({ score, isRanked, isHighlighted, showAccuracy, re
                         {rankDisplay}
                      </span>
                      <span className="text-muted-foreground text-[11px]">
-                        <Time short date={score.createdAt} longRelativeClassName="text-[10.5px]" />
+                        <Time
+                           short
+                           date={score.createdAt}
+                           longRelativeClassName="[font-size:var(--short-time-font-size)]"
+                           shortFitTargetLength={12}
+                           minShortFitScale={0.85}
+                        />
                      </span>
                   </div>
                   <PlayerAvatar

--- a/src/modules/scores/score-rank.tsx
+++ b/src/modules/scores/score-rank.tsx
@@ -34,7 +34,7 @@ export function ScoreRank({ rank, scoreId, mapId, leaderboardId, timeSet, hmdNam
             </mapDifficultyRoute.Link>
          </span>
          <span className="absolute top-0 left-1/2 -translate-x-1/2 text-center whitespace-nowrap lg:static lg:translate-x-0">
-            <Time short={true} date={timeSet} longRelativeClassName="lg:text-[10px]" />
+            <Time short={true} date={timeSet} longRelativeClassName="lg:[font-size:var(--short-time-font-size)]" />
          </span>
          <DeviceDisplay
             hmd={hmdName}

--- a/src/shared/components/time.tsx
+++ b/src/shared/components/time.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { useLocale, useTranslations } from 'use-intl';
@@ -14,6 +15,8 @@ type TimeProps = {
    dateOnly?: boolean;
    className?: string;
    longRelativeClassName?: string;
+   shortFitTargetLength?: number;
+   minShortFitScale?: number;
 };
 
 const RELATIVE_UNITS: { seconds: number; unit: Intl.RelativeTimeFormatUnit }[] = [
@@ -24,9 +27,10 @@ const RELATIVE_UNITS: { seconds: number; unit: Intl.RelativeTimeFormatUnit }[] =
    { seconds: 60, unit: 'minute' }
 ];
 
-const LONG_SHORT_TIME_LENGTH = 12;
+const LONG_SHORT_TIME_LENGTH = 11;
+const MIN_SHORT_TIME_SCALE = 0.65;
 
-export function Time({ date, short, dateOnly, className, longRelativeClassName }: TimeProps) {
+export function Time({ date, short, dateOnly, className, longRelativeClassName, shortFitTargetLength, minShortFitScale }: TimeProps) {
    const dateObj = date == null ? null : new Date(date);
    const [mounted, setMounted] = useState(false);
    const locale = useLocale();
@@ -57,6 +61,7 @@ export function Time({ date, short, dateOnly, className, longRelativeClassName }
    }
 
    const displayText = mounted ? timeAgo(dateObj, short, formatters, t('justNow')) : formatters.shortDate.format(dateObj);
+   const shortTimeStyle = getShortTimeStyle(displayText, !!(short && longRelativeClassName), shortFitTargetLength, minShortFitScale);
 
    return (
       <Tooltip>
@@ -68,6 +73,7 @@ export function Time({ date, short, dateOnly, className, longRelativeClassName }
                   short && 'whitespace-nowrap',
                   short && displayText.length > LONG_SHORT_TIME_LENGTH && longRelativeClassName
                )}
+               style={shortTimeStyle}
                suppressHydrationWarning
             >
                {displayText}
@@ -78,6 +84,13 @@ export function Time({ date, short, dateOnly, className, longRelativeClassName }
          </TooltipContent>
       </Tooltip>
    );
+}
+
+function getShortTimeStyle(text: string, enabled: boolean, targetLength = LONG_SHORT_TIME_LENGTH, minScale = MIN_SHORT_TIME_SCALE) {
+   if (!enabled || text.length <= targetLength) return undefined;
+
+   const scale = Math.max(minScale, targetLength / text.length);
+   return { '--short-time-font-size': `${scale}em` } as CSSProperties;
 }
 
 function timeAgo(date: Date, isShort: boolean | undefined, formatters: TimeFormatters, justNow: string) {


### PR DESCRIPTION
Fixes #158 

#### changes
- removed static downsizing
- dynamically scales long localized relative timestamps

#### before
<img width="470" height="210" alt="image" src="https://github.com/user-attachments/assets/f01c19a3-2960-47b2-817b-bd61d0a20a8d" />

#### after
<img width="477" height="211" alt="image" src="https://github.com/user-attachments/assets/b606275d-40d3-457d-9ad4-1083cd255764" />