### PR TITLE
i18n: detect browser locale on first visit (#155)

### DIFF
--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -138,6 +138,9 @@ function matchLocale(value: string): Locale | null {
    const exact = locales.find((locale) => locale.toLowerCase() === requested);
    if (exact) return exact;
 
+   if (requested.startsWith('zh-hans')) return 'zh-CN';
+   if (requested.startsWith('zh-hant')) return 'zh-TW';
+
    const language = requested.split('-')[0];
    return locales.find((locale) => locale.toLowerCase() === language || locale.toLowerCase().startsWith(`${language}-`)) ?? null;
 }

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -25,7 +25,7 @@ type AcceptedLocale = {
    quality: number;
 };
 
-const MIN_AUTO_LOCALE_COMPLETION = 0.8;
+const MIN_AUTO_LOCALE_COMPLETION = 0.35;
 
 const localeMessages: Record<Locale, Messages> = {
    en: enMessages,

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -1,4 +1,4 @@
-import { getCookie } from '@tanstack/react-start/server';
+import { getCookie, getRequestHeaders } from '@tanstack/react-start/server';
 
 import csCzMessages from '../../messages/cs-CZ.json';
 import deDeMessages from '../../messages/de-DE.json';
@@ -20,6 +20,12 @@ import zhTwMessages from '../../messages/zh-TW.json';
 import { defaultLocale, locales, parseLocale, type Locale } from '@/i18n/config';
 
 type Messages = Record<string, string | Messages>;
+type AcceptedLocale = {
+   value: string;
+   quality: number;
+};
+
+const MIN_AUTO_LOCALE_COMPLETION = 0.8;
 
 const localeMessages: Record<Locale, Messages> = {
    en: enMessages,
@@ -40,8 +46,16 @@ const localeMessages: Record<Locale, Messages> = {
    'fi-FI': fiFiMessages
 };
 
+const totalMessageCount = countMessages(enMessages);
+const localeCompletion = Object.fromEntries(
+   locales.map((locale) => [locale, locale === defaultLocale ? 1 : countTranslatedMessages(enMessages, localeMessages[locale]) / totalMessageCount])
+) as Record<Locale, number>;
+
 export async function getLocale(): Promise<Locale> {
-   return parseLocale(getCookie('locale'));
+   const cookieLocale = getCookie('locale');
+   if (cookieLocale) return parseLocale(cookieLocale);
+
+   return getAcceptedLocale(getRequestHeaders().get('accept-language')) ?? defaultLocale;
 }
 
 export async function getMessages(): Promise<Messages> {
@@ -87,4 +101,54 @@ function mergeMessage(base: string | Messages, override: string | Messages | und
 
 function hasMessages(value: string | Messages): boolean {
    return typeof value === 'string' ? value.trim().length > 0 : Object.values(value).some(hasMessages);
+}
+
+function getAcceptedLocale(header: string | null): Locale | null {
+   for (const { value } of parseAcceptedLocales(header)) {
+      const locale = matchLocale(value);
+      if (locale && localeCompletion[locale] >= MIN_AUTO_LOCALE_COMPLETION) return locale;
+   }
+
+   return null;
+}
+
+function parseAcceptedLocales(header: string | null): AcceptedLocale[] {
+   if (!header) return [];
+
+   return header
+      .split(',')
+      .map((part) => {
+         const [value, ...params] = part.trim().split(';');
+         const quality = params
+            .map((param) => param.trim())
+            .find((param) => param.startsWith('q='))
+            ?.slice(2);
+
+         return {
+            value,
+            quality: quality ? Number(quality) : 1
+         };
+      })
+      .filter((locale) => locale.value && Number.isFinite(locale.quality) && locale.quality > 0)
+      .sort((a, b) => b.quality - a.quality);
+}
+
+function matchLocale(value: string): Locale | null {
+   const requested = value.toLowerCase();
+   const exact = locales.find((locale) => locale.toLowerCase() === requested);
+   if (exact) return exact;
+
+   const language = requested.split('-')[0];
+   return locales.find((locale) => locale.toLowerCase() === language || locale.toLowerCase().startsWith(`${language}-`)) ?? null;
+}
+
+function countMessages(value: string | Messages): number {
+   return typeof value === 'string' ? 1 : Object.values(value).reduce((total, next) => total + countMessages(next), 0);
+}
+
+function countTranslatedMessages(base: string | Messages, override: string | Messages | undefined): number {
+   if (typeof base === 'string') return typeof override === 'string' && override.trim() ? 1 : 0;
+   if (!override || typeof override === 'string') return 0;
+
+   return Object.entries(base).reduce((total, [key, value]) => total + countTranslatedMessages(value, override[key]), 0);
 }


### PR DESCRIPTION
Fixes #155

#### changes
- detects the browser locale from `Accept-Language` when no locale cookie is set
- only auto selects locales with at least `80%+ (subject to change)`  translation coverage
- falls back to the default English for unsupported or incomplete locales
- manual language selection always overrides browser detection

### examples

- #### First time visit (no cookie), Browser set to Korean (translation > 80% complete)
<img width="341" height="344" alt="image" src="https://github.com/user-attachments/assets/64c15e62-a67b-4a2c-b831-0a1755943ac5" />

- #### First time visit (no cookie), Browser set to Russian (translation < 80% complete, defaults to EN)
<img width="330" height="335" alt="image" src="https://github.com/user-attachments/assets/3a6cfe44-6425-4d0a-9acf-8a0f6effaac7" />

- #### Manually set site language to English, Browser set to Korean (locale cookie always overrides)
<img width="330" height="335" alt="image" src="https://github.com/user-attachments/assets/05d80d6f-1c1e-48c9-8c45-3d9e46528e86" />

- #### First time visit (no cookie), Browser set to Hindi (language not supported, defaults to EN)
<img width="330" height="335" alt="image" src="https://github.com/user-attachments/assets/05d80d6f-1c1e-48c9-8c45-3d9e46528e86" />