### PR TITLE
time: use short russian timestamps (#163)

### DIFF
--- a/src/shared/components/time.tsx
+++ b/src/shared/components/time.tsx
@@ -109,9 +109,11 @@ function timeAgo(date: Date, isShort: boolean | undefined, formatters: TimeForma
 type TimeFormatters = ReturnType<typeof createTimeFormatters>;
 
 function createTimeFormatters(locale: string) {
+   const shortRelativeStyle: Intl.RelativeTimeFormatStyle = locale.toLowerCase().startsWith('ru') ? 'short' : 'narrow';
+
    return {
       relativeLong: new Intl.RelativeTimeFormat(locale, { numeric: 'always', style: 'long' }),
-      relativeShort: new Intl.RelativeTimeFormat(locale, { numeric: 'always', style: 'narrow' }),
+      relativeShort: new Intl.RelativeTimeFormat(locale, { numeric: 'always', style: shortRelativeStyle }),
       fullDate: new Intl.DateTimeFormat(locale, {
          weekday: 'long',
          year: 'numeric',


### PR DESCRIPTION
Fixes #163 

#### changes
- prefer 'short' over 'narrow' in the Intl timestamp formatting for languages like Russian
- other languages can also be easily added in the future if needed