### PR TITLE
score: remove score value icon (#177)

### DIFF
--- a/src/modules/scores/score-stats.tsx
+++ b/src/modules/scores/score-stats.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, Clock, Hash, Info, Star, Target, X } from 'lucide-react';
+import { Check, Clock, Info, Star, Target, X } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -93,7 +93,7 @@ export function ScoreStats({
          <div className="flex items-center gap-2">
             <Tooltip>
                <TooltipTrigger asChild>
-                  <Stat icon={Hash} className="cursor-default">
+                  <Stat className="cursor-default">
                      <span className="inline-flex items-baseline gap-1.5">
                         {formatNumber(score.modifiedScore)}
                         {score.mods.length > 0 && <span className="text-muted-foreground text-[10px] font-semibold">{score.mods.join(', ')}</span>}

--- a/src/shared/components/stat.tsx
+++ b/src/shared/components/stat.tsx
@@ -5,7 +5,7 @@ import type { IconType } from 'react-icons';
 import { cn } from '@/shared/format/helpers';
 
 interface StatProps extends React.HTMLAttributes<HTMLDivElement> {
-   icon: IconType | React.ComponentType<{ className?: string }>;
+   icon?: IconType | React.ComponentType<{ className?: string }>;
    label?: string;
    children: React.ReactNode;
    labelClassName?: string;
@@ -21,7 +21,7 @@ export const Stat = forwardRef<HTMLDivElement, StatProps>(
             className={cn('bg-secondary/35 text-muted-foreground inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs', className)}
             {...props}
          >
-            <Icon className={cn('h-3 w-3 shrink-0', iconClassName)} />
+            {Icon ? <Icon className={cn('h-3 w-3 shrink-0', iconClassName)} /> : null}
             {label ? <span className={cn('cursor-default select-none', labelClassName)}>{label}</span> : null}
             <span className={cn('text-foreground font-semibold', valueClassName)}>{children}</span>
          </div>


### PR DESCRIPTION
Fixes #177 

#### changes
- remove score value Hash icon
- lets the shared stat component render without an icon when needed