### PR TITLE
rankings: preserve country filters during pagination

### DIFF
--- a/src/shared/url-state/search-serializer.ts
+++ b/src/shared/url-state/search-serializer.ts
@@ -32,7 +32,7 @@ export function normalizeSearchRecord(search: Record<string, unknown>) {
       if (Array.isArray(value)) {
          params[key] = value.length > 0 ? String(value[value.length - 1]) : undefined;
       } else if (value != null) {
-         params[key] = String(value);
+         params[key] = typeof value === 'object' ? formatObjectSearchValue(value as Record<string, unknown>) : String(value);
       }
    }
 


### PR DESCRIPTION
Fixes https://hub.scoresaber.com/b/bug-reports/posts/post_01kv0q2agffvgaj5xd4c0y6rs0

wasn't set to planned, but it was quite a serious issue as it breaks like every other page

the invalid normalized value could override the valid parsed search.countries, causing the loader to drop the country filter even while the URL still contained countries=CA

#### changes
- fixes parsed country filters being normalized as [object Object]